### PR TITLE
chore: react-dom 버전 이슈로 인해 버전업 및 index.tsx수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="./src/assets/gomao.png" />
-    <link rel="stylesheet" href="/tailwind.css" />
+    <!-- <link rel="stylesheet" href="/tailwind.css" /> -->
 
     <title>Gomao's React Vite App</title>
+    <script type="module" src="index.tsx"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="index.tsx"></script>
   </body>
 </html>

--- a/index.tsx
+++ b/index.tsx
@@ -1,6 +1,5 @@
-import ReactDOM from "react-dom";
 import App from "./App";
-
-const rootElement = document.getElementById("root");
-
-ReactDOM.render(<App />, rootElement);
+import { createRoot } from "react-dom/client";
+const container = document.getElementById("root")!;
+const root = createRoot(container); // createRoot(container!) if you use TypeScript
+root.render(<App />);

--- a/src/components/LoginFormInput.tsx
+++ b/src/components/LoginFormInput.tsx
@@ -1,7 +1,18 @@
 import React from "react";
 
-function LoginFormInput() {
-  return <div>LoginFormInput</div>;
+interface DataInputProps {
+  label: string;
+  type: string;
+  id: string;
+}
+
+function LoginFormInput({ label, type, id }: DataInputProps) {
+  return (
+    <>
+      <label htmlFor={label}></label>
+      <input type={type} id={id} />
+    </>
+  );
 }
 
 export default LoginFormInput;

--- a/src/pages/Admin/AdminLogin.tsx
+++ b/src/pages/Admin/AdminLogin.tsx
@@ -1,10 +1,11 @@
 import React from "react";
+import LoginFormInput from "@components/LoginFormInput";
 
 function AdminLogin() {
   return (
     <>
-      <div className="bg-blue-500 text-white p-4">
-        This is a Tdddailwind CSS component!
+      <div>
+        <LoginFormInput label="아이디" id="id" type="text" />
       </div>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,7 +1661,7 @@ queue-microtask@^1.2.2:
 
 react-dom@^18.2.0:
   version "18.2.0"
-  resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
   integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
@@ -1684,7 +1684,7 @@ react-router@6.16.0:
 
 react@^18.2.0:
   version "18.2.0"
-  resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"


### PR DESCRIPTION
ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it’s running React 17. 
해당 오류로 react-dom 을 최신버전으로 내려받고, index.tsx파일을 수정했습니다.